### PR TITLE
Support @ as comment character

### DIFF
--- a/resolve_march_native/parser.py
+++ b/resolve_march_native/parser.py
@@ -14,7 +14,7 @@ def extract_flags(text):
     start_marker_seen = False
 
     for line in text.split('\n'):
-        if not line.startswith('#'):
+        if not (line.startswith('#') or line.startswith('@')):
             continue
 
         if not start_marker_seen:


### PR DESCRIPTION
Some assemblers prefer the @ character instead of # for comments. Most
notably the GNU ARM assembler, as denoted here:
https://sourceware.org/binutils/docs/as/ARM_002dChars.html#ARM_002dChars

The verbose-arm function of the GNU C compiler also uses @ to provide
verbose information.

With this change, # as well as @ can be used, effectively making it
possible to use this program on ARM machines.