### PR TITLE
Drop argument --keep-default-params and always keep "--param {k}={v}" (fixes #45)

### DIFF
--- a/resolve_march_native/__main__.py
+++ b/resolve_march_native/__main__.py
@@ -39,9 +39,6 @@ def _inner_main():
                         '(default: stripped away)')
     parser.add_argument('--keep-mno-flags', action='store_true',
                         help='keep -mno-* parameters (default: (superfluous ones) stripped away)')
-    parser.add_argument('--keep-default-params', action='store_true',
-                        help='keep --param ... with values matching defaults'
-                             ' (default: stripped away)')
     parser.add_argument('--add-recommended', '-a', action='store_true',
                         help='add recommended flags (default: not added)')
     parser.add_argument('--version', action='version',

--- a/resolve_march_native/engine.py
+++ b/resolve_march_native/engine.py
@@ -52,21 +52,6 @@ class Engine:
             if flag.startswith('-mno-'):
                 flag_set.remove(flag)
 
-    def _resolve_default_params(self, flag_set):
-        defaults = {
-            'l1-cache-line-size': 32,
-            'l1-cache-size': 64,
-            'l2-cache-size': 512,
-        }
-        needle_set = {f'--param {k}={v}' for k, v in defaults.items()}
-
-        for flag in list(flag_set):
-            if flag in needle_set:
-                if self._debug:
-                    print('Stripping %s because it is repeating defaults, only.' %
-                          flag, file=sys.stderr)
-                flag_set.remove(flag)
-
     def _get_march_native_flag_set(self):
         march_native_flag_set = set(extract_flags(
             run(self._gcc_command, ['-march=native'], self._debug)))
@@ -111,8 +96,6 @@ class Engine:
             self._resolve_mtune(native_unrolled_flag_set, arch)
         if not options.keep_mno_flags:
             self._resolve_mno_flags(native_unrolled_flag_set)
-        if not options.keep_default_params:
-            self._resolve_default_params(native_unrolled_flag_set)
 
         # NOTE: The next step needs to go after resolution of -mno-* flags
         #       since it may add new -mno-* flags

--- a/resolve_march_native/test/test_engine.py
+++ b/resolve_march_native/test/test_engine.py
@@ -54,6 +54,7 @@ class TestEngine(TestCase):
         expected_flag_set = {
             '--param l1-cache-size=24',
             '--param l1-cache-line-size=64',
+            '--param l2-cache-size=512',
             '-march=bonnell',
             '-mno-cx16',
         }


### PR DESCRIPTION
Fixes #45