### PR TITLE
`run-tests.yml`: Drop call to `python3 setup.py test`

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,9 +25,6 @@ jobs:
         set -x
         python3 --version
         pip3 install -U setuptools  # for Python >=3.12
-        python3 setup.py test
-
-        # Once again with pytest for its warnings
         pip3 install --require-hashes -r requirements.txt
         pytest -v -s -Wdefault -Werror
 


### PR DESCRIPTION
.. because Setuptools >=72 stopped providing that command:

https://setuptools.pypa.io/en/stable/history.html#v72-0-0