### PR TITLE
`run-tests.yml`: Stop adding Ubuntu 25.04 for GCC 15 (to fix CI)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
 
-    - name: Add GCC 15 Ubuntu repositories
+    - name: Add repository "ubuntu-toolchain-r" for GCC 15
       if: "${{ matrix.cc == 'gcc-15' }}"
       run: |
         set -x
@@ -69,7 +69,6 @@ jobs:
         # NOTE: plucky is 25.04 (not 24.04 LTS)
         wget -O - 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xc8ec952e2a0e1fbdc5090f6a2c277a0a352154e5' | sudo apt-key add -
         sudo add-apt-repository 'deb https://ppa.launchpadcontent.net/ubuntu-toolchain-r/test/ubuntu plucky main'
-        sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ plucky main'
 
     - name: Install runtime dependencies
       if: "${{ matrix.install }}"


### PR DESCRIPTION
The symptom was:
```
The following packages have unmet dependencies:
 gcc-15 : Depends: gcc-15-x86-64-linux-gnu (= 15-20250304-0ubuntu2) but it is not going to be installed
          Depends: gcc-15-base (= 15-20250304-0ubuntu2) but 15-20250315-1ubuntu1 is to be installed
          Depends: cpp-15 (= 15-20250304-0ubuntu2) but it is not going to be installed
```