### PR TITLE
CI: Stop using about-to-be-removed image "macos-13"

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,7 +29,7 @@ jobs:
           - cc: gcc-12
             install: null
             python-version: 3.9
-            runs-on: macos-13
+            runs-on: macos-14
           - cc: gcc-12
             install: null
             python-version: 3.9
@@ -37,7 +37,7 @@ jobs:
           - cc: gcc-14
             install: null
             python-version: 3.13
-            runs-on: macos-13
+            runs-on: macos-14
           - cc: gcc-14
             install: null
             python-version: 3.13


### PR DESCRIPTION
> The macOS 13 runner image will be retired by December 4th, 2025.